### PR TITLE
ignore read bases containing 'N'

### DIFF
--- a/aldy/sam.py
+++ b/aldy/sam.py
@@ -255,6 +255,8 @@ class SAM(object):
 					elif op in [0, 7, 8]:
 						for i in range(size):
 							if 0 <= start + i - chr_start < len(ref) and ref[start + i - chr_start] != seq[s_start + i]:
+								if seq[s_start + i] == 'N':
+									continue  # ignore read bases with N in it
 								mut = (start + i, 'SNP.{}{}'.format(ref[start + i - chr_start], seq[s_start + i]))
 								muts[mut] += 1
 								if SAM.PHASE: 


### PR DESCRIPTION
Sometimes Illumina reads may have Ns in them. When aldy encountered one, it gave this error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/aldy/genotype.py", line 60, in genotype
    score, init_sol = protein.get_initial_solution(gene, sample, cn_sol, solver)
  File "/usr/local/lib/python2.7/dist-packages/aldy/protein.py", line 44, in get_initial_solution
    structure
  File "/usr/local/lib/python2.7/dist-packages/aldy/protein.py", line 106, in solve_ilp
    if check_functional(gene, Mutation(pos, op)):
  File "/usr/local/lib/python2.7/dist-packages/aldy/common.py", line 82, in check_functional
    amino = seq_to_amino(rev_comp(seq) if gene.rev_comp else seq)
  File "/usr/local/lib/python2.7/dist-packages/aldy/common.py", line 69, in rev_comp
    return ''.join([REV_COMPLEMENT[x] for x in seq[::-1]])
KeyError: 'N'
```

The fix in this PR ignores bases with Ns when tabulating variants, which prevents this downstream issue.