### PR TITLE
Update cyp2d6.yml

### DIFF
--- a/aldy/resources/genes/cyp2d6.yml
+++ b/aldy/resources/genes/cyp2d6.yml
@@ -1383,7 +1383,7 @@
       "mutations": [
         {"pos": 42525131, "op": "SNP.CG", "old": "1661:G>C", "functional": 0, "dbsnp": ["rs1058164"]}, 
         {"pos": 42523942, "op": "SNP.GA", "old": "2850:C>T", "functional": 1, "dbsnp": ["rs16947"]}, 
-        {"pos": 42523531, "op": "INS.ca", "old": "3259:insGT", "functional": 3, "dbsnp": ["rs72549346"]}, 
+        {"pos": 42523532, "op": "INS.ca", "old": "3259:insGT", "functional": 3, "dbsnp": ["rs72549346"]}, 
         {"pos": 42522612, "op": "SNP.CG", "old": "4180:G>C", "functional": 1, "dbsnp": ["rs1135840"]}
       ]
     }, 


### PR DESCRIPTION
The coordinate for the repeat insertion is 42523532. It appears in the log files where *42 is supposed to be present.